### PR TITLE
Add last quote and rename bar to bars

### DIFF
--- a/fixture/vcr_cassettes/last_quote/get_failure.json
+++ b/fixture/vcr_cassettes/last_quote/get_failure.json
@@ -1,0 +1,32 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "APCA-API-KEY-ID": "***",
+        "APCA-API-SECRET-KEY": "***"
+      },
+      "method": "get",
+      "options": {
+        "recv_timeout": 30000
+      },
+      "request_body": "",
+      "url": "https://data.alpaca.markets/v1/last_quote/stocks/FFFFF"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"code\":40410000,\"message\":\"resource not found\"}",
+      "headers": {
+        "Server": "nginx/1.16.1",
+        "Date": "Sun, 28 Jun 2020 17:34:11 GMT",
+        "Content-Type": "application/json; charset=UTF-8",
+        "Content-Length": "48",
+        "Connection": "keep-alive",
+        "Access-Control-Allow-Credentials": "true",
+        "Vary": "Origin"
+      },
+      "status_code": 404,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/last_quote/get_success.json
+++ b/fixture/vcr_cassettes/last_quote/get_success.json
@@ -1,0 +1,32 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "APCA-API-KEY-ID": "***",
+        "APCA-API-SECRET-KEY": "***"
+      },
+      "method": "get",
+      "options": {
+        "recv_timeout": 30000
+      },
+      "request_body": "",
+      "url": "https://data.alpaca.markets/v1/last_quote/stocks/AAPL"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"status\":\"success\",\"symbol\":\"AAPL\",\"last\":{\"askprice\":0,\"asksize\":0,\"askexchange\":0,\"bidprice\":0,\"bidsize\":0,\"bidexchange\":2,\"timestamp\":1593205454888000000}}",
+      "headers": {
+        "Server": "nginx/1.16.1",
+        "Date": "Sun, 28 Jun 2020 17:34:10 GMT",
+        "Content-Type": "application/json; charset=UTF-8",
+        "Content-Length": "159",
+        "Connection": "keep-alive",
+        "Access-Control-Allow-Credentials": "true",
+        "Vary": "Origin"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/alpaca/models/bars.ex
+++ b/lib/alpaca/models/bars.ex
@@ -1,4 +1,4 @@
-defmodule Alpaca.Bar do
+defmodule Alpaca.Bars do
   @moduledoc """
   A resource that allows us to query the Bars data from Alpaca
   The bars API provides time-aggregated price and volume data.

--- a/lib/alpaca/models/last/quote.ex
+++ b/lib/alpaca/models/last/quote.ex
@@ -1,0 +1,20 @@
+defmodule Alpaca.Last.Quote do
+  @moduledoc """
+  A resource that allows us to query for the last quote details for a symbol
+
+  A last quote has the following methods we can call on it
+  ```
+  get/1
+  ```
+
+  The `get/1` method allows us to get a singular last quote for a given symbol by calling
+  `Alpaca.Last.Quote.get(symbol)`. Where `symbol` is the
+  stock symbol you want to retrieve last quote information for.
+  """
+  alias Alpaca.Client
+
+  use Alpaca.Resource,
+    endpoint: "last_quote/stocks",
+    exclude: [:list, :create, :edit, :delete, :delete_all, :update],
+    opts: [version: "v1", api_host: Client.data_api_host()]
+end

--- a/lib/alpaca/models/last/trade.ex
+++ b/lib/alpaca/models/last/trade.ex
@@ -2,12 +2,12 @@ defmodule Alpaca.Last.Trade do
   @moduledoc """
   A resource that allows us to query for the last trade of a symbol
 
-  An last trade activity has the following methods we can call on it
+  A last trade has the following methods we can call on it
   ```
   get/1
   ```
 
-  The `get/1` method allows us to get a singulat last trade for a given symbol by calling
+  The `get/1` method allows us to get a singular last trade for a given symbol by calling
   `Alpaca.Last.Trade.get(symbol)`. Where `symbol` is the
   stock symbol you want to retrieve last trade information for.
   """

--- a/test/alpaca/models/bars_test.exs
+++ b/test/alpaca/models/bars_test.exs
@@ -1,13 +1,13 @@
-defmodule Alpaca.BarTest do
+defmodule Alpaca.BarsTest do
   use ExUnit.Case, async: true
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
-  alias Alpaca.Bar
+  alias Alpaca.Bars
 
   describe "list/2" do
     test "gets the bars list successfully" do
       use_cassette "bar/list_success" do
-        assert {:ok, %{AAPL: bars}} = Bar.list("day", %{symbols: "AAPL"})
+        assert {:ok, %{AAPL: bars}} = Bars.list("day", %{symbols: "AAPL"})
 
         assert length(bars) == 100
       end
@@ -19,7 +19,7 @@ defmodule Alpaca.BarTest do
                 %{
                   body: %{code: 40_010_001, message: "at least one symbol is required"},
                   status: 422
-                }} = Bar.list("day")
+                }} = Bars.list("day")
       end
     end
   end

--- a/test/alpaca/models/last/quote_test.exs
+++ b/test/alpaca/models/last/quote_test.exs
@@ -1,0 +1,21 @@
+defmodule Alpaca.QuoteTest do
+  use ExUnit.Case, async: true
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  alias Alpaca.Last.Quote
+
+  describe "get/1" do
+    test "gets the last quote successfully" do
+      use_cassette "last_quote/get_success" do
+        assert {:ok, %{status: "success", symbol: "AAPL", last: last}} = Quote.get("AAPL")
+      end
+    end
+
+    test "gets the last quote unsuccessfully" do
+      use_cassette "last_quote/get_failure" do
+        assert {:error, %{status: 404, body: %{code: 40_410_000, message: "resource not found"}}} =
+                 Quote.get("FFFFF")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add last quote get endpoint and rename bar to bars to more align
with the API. this is technically a breaking change.