### PR TITLE
Fix Alpaca websocket authentication procedure

### DIFF
--- a/lib/alpaca/stream.ex
+++ b/lib/alpaca/stream.ex
@@ -152,10 +152,8 @@ defmodule Alpaca.Stream do
         authentication_json =
           %{
             action: "auth",
-            data: %{
-              key: Client.client_id(),
-              secret: Client.client_secret()
-            }
+            key: Client.client_id(),
+            secret: Client.client_secret()
           }
           |> Jason.encode!()
 

--- a/lib/alpaca/stream.ex
+++ b/lib/alpaca/stream.ex
@@ -93,8 +93,8 @@ defmodule Alpaca.Stream do
       end
       ```
       """
-      def start_link(streams) do
-        {:ok, pid} = WebSockex.start_link(unquote(url), __MODULE__, :no_state)
+      def start_link(streams, opts \\ []) do
+        {:ok, pid} = WebSockex.start_link(unquote(url), __MODULE__, :no_state, opts)
         authenticate(pid)
 
         unless streams == [] do


### PR DESCRIPTION
Current documentation for the Alpaca streaming API expects the web socket authentication message to contain
a flat JSON object with the keys "action", "key" and "secret".

![image](https://github.com/user-attachments/assets/7dc40012-7423-4e4c-8ee7-fafffef2b237)


When debugging the issue I realized that Websockex accepts some optional parameters (for enabling debugging) so I added that into Alpaca.Stream as well :)